### PR TITLE
Make get_process_name_by_pid more robust and cross-platform (see: #127)

### DIFF
--- a/src/hstr_utils.c
+++ b/src/hstr_utils.c
@@ -149,7 +149,7 @@ char *get_process_name_by_pid(const int pid)
       char* shell = strrchr(getenv("SHELL"),'/');
       if(shell != NULL){
         shell++;
-        strncpy(name,shell,sizeof(char)*sizeof(name));
+        strncpy(name,shell,sizeof(char)*strlen(shell));
       }
     }
     return name;

--- a/src/hstr_utils.c
+++ b/src/hstr_utils.c
@@ -144,6 +144,14 @@ char *get_process_name_by_pid(const int pid)
             fclose(f);
         }
     }
+    // if name isn't e.g. bash/zsh at this point, fall back to $SHELL
+    if(strlen(name) > 4){
+      char* shell = strrchr(getenv("SHELL"),'/');
+      if(shell != NULL){
+        shell++;
+        strncpy(name,shell,sizeof(char)*sizeof(name));
+      }
+    }
     return name;
 }
 


### PR DESCRIPTION
By falling back to $SHELL environment variable.