### PR TITLE
Use Mac-specific checks for ncurses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,8 +16,20 @@ AM_INIT_AUTOMAKE
 # Checks for programs.
 AC_PROG_CC
 
+# Mac-specific ncurses check
+AC_CANONICAL_HOST
+case $host_os in
+  darwin*)
+    AC_CHECK_LIB(ncurses, killwchar, [], [AC_MSG_ERROR([Could  not find ncurses library])])
+    AC_CHECK_HEADER(curses.h)
+    ;;
+  *)
+    AC_CHECK_LIB(ncursesw, killwchar, [], [AC_MSG_ERROR([Could  not find ncursesw library])])
+    AC_CHECK_HEADER(ncursesw/curses.h)
+    ;;
+esac
+
 # Checks for libraries.
-AC_CHECK_LIB(ncursesw, killwchar, [], [AC_MSG_ERROR([Could  not find ncursesw library])])
 AC_CHECK_LIB(m, cos, [], [AC_MSG_ERROR([Could not find m library])])
 AC_CHECK_LIB(readline, using_history, [], [AC_MSG_ERROR([Could not find readline library])])
 
@@ -28,7 +40,6 @@ AC_CHECK_HEADER(fcntl.h)
 AC_CHECK_HEADER(getopt.h)
 AC_CHECK_HEADER(locale.h)
 AC_CHECK_HEADER(math.h)
-AC_CHECK_HEADER(ncursesw/curses.h)
 AC_CHECK_HEADER(readline/history.h)
 AC_CHECK_HEADER(regex.h)
 AC_CHECK_HEADER(signal.h)

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -11,7 +11,11 @@
 
 #include <getopt.h>
 #include <locale.h>
+#ifdef __APPLE__
+#include <curses.h>
+#else
 #include <ncursesw/curses.h>
+#endif
 #include <readline/chardefs.h>
 #include <regex.h>
 #include <signal.h>

--- a/src/include/hstr_curses.h
+++ b/src/include/hstr_curses.h
@@ -10,7 +10,11 @@
 #ifndef _HSTR_CURSES_H
 #define _HSTR_CURSES_H
 
+#ifdef __APPLE__
+#include <curses.h>
+#else
 #include <ncursesw/curses.h>
+#endif
 
 #define color_attr_on(C) if(terminal_has_colors()) { attron(C); }
 #define color_attr_off(C) if(terminal_has_colors()) { attroff(C); }


### PR DESCRIPTION
With this change, I get a clean compile from source with:

    autoreconf -fvi
    ./configure CFLAGS=-I$(brew --prefix)/opt/readline/include LDFLAGS=-L$(brew --prefix)/opt/readline/lib
    make

On my Mac with Homebrew.

See #103.