### PR TITLE
Fixed #144, Strange cursor positions after deletions

### DIFF
--- a/src/hstr.c
+++ b/src/hstr.c
@@ -885,9 +885,7 @@ void loop_to_select(Hstr *hstr)
                 printDefaultLabel=TRUE;
                 print_history_label(hstr);
 
-                if(selectionCursorPosition>0) {
-                    selectionCursorPosition--;
-                } else {
+                if(selectionCursorPosition>=hstr->selectionSize) {
                     selectionCursorPosition=hstr->selectionSize-1;
                 }
                 highlight_selection(selectionCursorPosition, SELECTION_CURSOR_IN_PROMPT, pattern, hstr);


### PR DESCRIPTION
It was introduced in b769fabef9015614d874bc95ec5beea3330f6c8c, this patch should fix the cursor position in view:ranking and view:history.