### PR TITLE
Try to detect ncurses using pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,17 +18,21 @@ AC_PROG_CC
 
 # Platform specific ncurses check.
 AC_CANONICAL_HOST
-AS_CASE([$host_os],
-  [darwin*],
-    [
-      AC_CHECK_LIB(ncurses, killwchar, [], [AC_MSG_ERROR([Could not find ncurses library])])
-      AC_CHECK_HEADER(curses.h)
-    ],
-  [
-    AC_CHECK_LIB(ncursesw, killwchar, [], [AC_MSG_ERROR([Could not find ncursesw library])])
-    AC_CHECK_HEADER(ncursesw/curses.h)
-  ]
-)
+PKG_CHECK_MODULES([NCURSES], [ncursesw], [], [
+  PKG_CHECK_MODULES([NCURSES], [ncurses], [], [
+    AS_CASE([$host_os],
+      [darwin*],
+        [
+          AC_CHECK_LIB(ncurses, killwchar, [], [AC_MSG_ERROR([Could not find ncurses library])])
+          AC_CHECK_HEADER(curses.h)
+        ],
+      [
+        AC_CHECK_LIB(ncursesw, killwchar, [], [AC_MSG_ERROR([Could not find ncursesw library])])
+        AC_CHECK_HEADER(ncursesw/curses.h)
+      ]
+    )
+  ])
+])
 
 # Checks for libraries.
 AC_CHECK_LIB(m, cos, [], [AC_MSG_ERROR([Could not find m library])])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,3 +15,5 @@ hh_SOURCES = 									\
 	hstr_regexp.c include/hstr_regexp.h			\
 	radixsort.c include/radixsort.h 			\
 	hstr.c 
+
+hh_LDADD = $(NCURSES_LIBS)


### PR DESCRIPTION
In case tinfo code is split out from libncurses into libtinfo it
is more reliable to use pkg-config to detect all libs need for proper linking

Signed-off-by: Justin Lecher <jlec@gentoo.org>