### PR TITLE
Add Vim style C-j and C-k navigation keys

### DIFF
--- a/man/hh.1
+++ b/man/hh.1
@@ -54,7 +54,7 @@ Add currently selected command to favorites.
 \fBCtrl\-l\fR
 Make search pattern lowercase or uppercase.
 .TP
-\fBCtrl\-r\fR, \fBUP\fR arrow, \fBDOWN\fR arrow, \fBCtrl\-n\fR, \fBCtrl\-p\fR
+\fBCtrl\-r\fR, \fBUP\fR arrow, \fBDOWN\fR arrow, \fBCtrl\-n\fR, \fBCtrl\-p\fR, \fBCtrl\-j\fR, \fBCtrl\-k\fR
 Navigate in the history list. 
 .TP
 \fBTAB\fR, \fBRIGHT\fR arrow

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -58,6 +58,8 @@
 #define K_CTRL_G 7
 #define K_CTRL_H 8
 #define K_CTRL_L 12
+#define K_CTRL_J 10
+#define K_CTRL_K 11
 
 #define K_CTRL_N 14
 #define K_CTRL_P 16
@@ -74,7 +76,7 @@
 #define K_ESC 27
 #define K_TAB 9
 #define K_BACKSPACE 127
-#define K_ENTER 10
+#define K_ENTER 13
 
 #define HH_THEME_MONO   0
 #define HH_THEME_COLOR  1<<7
@@ -1153,6 +1155,7 @@ void loop_to_select(Hstr *hstr)
             move(hstr->promptY, basex+hstr_strlen(pattern));
             break;
         case KEY_UP:
+        case K_CTRL_K:
         case K_CTRL_P:
             previousSelectionCursorPosition=selectionCursorPosition;
             if(selectionCursorPosition>0) {
@@ -1187,6 +1190,7 @@ void loop_to_select(Hstr *hstr)
             break;
         case K_CTRL_R:
         case KEY_DOWN:
+        case K_CTRL_J:
         case K_CTRL_N:
             if(selectionCursorPosition==SELECTION_CURSOR_IN_PROMPT) {
                 if(hstr->promptBottom) {

--- a/src/hstr_curses.c
+++ b/src/hstr_curses.c
@@ -26,6 +26,7 @@ void hstr_curses_start()
     initscr();
     keypad(stdscr, TRUE);
     noecho();
+    nonl();
     terminalHasColors=has_colors();
     if(terminalHasColors) {
         start_color();


### PR DESCRIPTION
With many Vim style programs (including Emacs Evil) you navigate up and down list with `ctrl-j` and `ctrl-k`. I added these keys to hstr. They don't conflict with any current keybindings and should make navigation a little more natural for Vim users as opposed to `ctrl-n`/`ctrl-p`.