### PR TITLE
186: Remove Cygwin specific ifdefs, check for TIOCSTI definition.

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -113,10 +113,10 @@ make && make install
 hh --show-configuration >> ~/.bashrc
 ```
 
-CYGWIN
-------
+CYGWIN/WINDOWS
+--------------
 * install from source
-* configure `hh` (required on Cygwin for terminal autocompletion):
+* configure `hh` (required for for terminal autocompletion, as TIOCSTI ioctl syscall is missing.):
 ```bash
 hh --show-configuration >> ~/.bashrc
 ```

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -178,16 +178,16 @@ static const char *INSTALL_BASH_STRING=
         "\nexport HISTSIZE=${HISTFILESIZE}  # increase history size (default is 500)"
         "\nexport PROMPT_COMMAND=\"history -a; history -n; ${PROMPT_COMMAND}\"   # mem/file sync"
         "\n# if this is interactive shell, then bind hh to Ctrl-r (for Vi mode check doc)"
-#ifndef __CYGWIN__
+#ifdef TIOCSTI
         "\nif [[ $- =~ .*i.* ]]; then bind '\"\\C-r\": \"\\C-a hh -- \\C-j\"'; fi"
 #else
-        "\nfunction hstr_cygwin {"
+        "\nfunction hstr_notiocsti {"
         "\n  offset=${READLINE_POINT}"
         "\n  READLINE_POINT=0"
         "\n  { READLINE_LINE=$(</dev/tty hstr ${READLINE_LINE:0:offset} 2>&1 1>&$hstrout); } {hstrout}>&1"
         "\n  READLINE_POINT=${#READLINE_LINE}"
         "\n}"
-        "\nif [[ $- =~ .*i.* ]]; then bind -x '\"\\C-r\": \"hstr_cygwin\"'; fi"
+        "\nif [[ $- =~ .*i.* ]]; then bind -x '\"\\C-r\": \"hstr_notiocsti\"'; fi"
 #endif
         "\n\n";
 

--- a/src/hstr_utils.c
+++ b/src/hstr_utils.c
@@ -73,7 +73,7 @@ void hstr_chop(char *s)
     }
 }
 
-#ifndef __CYGWIN__
+#ifdef TIOCSTI
 void tiocsti()
 {
     char buf[] = DEFAULT_COMMAND;
@@ -87,7 +87,7 @@ void tiocsti()
 void fill_terminal_input(char *cmd, bool padding)
 {
     if(cmd && strlen(cmd)>0) {
-#ifndef __CYGWIN__
+#ifdef TIOCSTI
         size_t size = strlen(cmd);
         unsigned i;
         char *c;

--- a/src/include/hstr_utils.h
+++ b/src/include/hstr_utils.h
@@ -33,7 +33,7 @@
 char *hstr_strdup(const char *s);
 int hstr_strlen(const char *s);
 void hstr_chop(char *s);
-#ifndef __CYGWIN__
+#ifdef TIOCSTI
 void tiocsti();
 #endif
 void fill_terminal_input(char* cmd, bool padding);


### PR DESCRIPTION
Fix for https://github.com/dvorka/hstr/issues/186. Identical to #164, just check for TIOCSTI directly instead of checking for `__CYGWIN__` define. Works on Cygwin, may also work on Windows 10 Linux Subsystem.

**Needs testing on Windows 10!** (I don't have a Win 10 machine):

```
git clone https://github.com/jmiserez/hstr
cd hstr
git checkout windows-fix
cd dist
./1-dist.sh
cd ..
./configure
make
make install
hh --show-configuration >> ~/.bashrc
```
Then open a new Bash and test it with CTRL-R.