### PR TITLE
Fixes crash with prompt-bottom, code cleanup and move help/status label

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -21,17 +21,17 @@ Check also configuration [examples](#examples).
 BINDING HSTR TO KEYBOARD SHORTCUT
 ---------------------------------
 Bash uses *Emacs* style keyboard shortcuts by default. There is
-also *Vi* mode. Find out how to bind HSTR to a keyboard shortcut 
+also *Vi* mode. Find out how to bind HSTR to a keyboard shortcut
 based on the style you prefer below.
 
 Check your active Bash keymap with:
 ```bash
 bind -v | grep editing-mode
 bind -v | grep keymap
-``` 
+```
 
-To determine character sequence emitted by a pressed key in 
-terminal, type <kbd>Ctrl-v</kbd> and then press the key. Check your 
+To determine character sequence emitted by a pressed key in
+terminal, type <kbd>Ctrl-v</kbd> and then press the key. Check your
 current bindings using:
 ```bash
 bind -S
@@ -90,6 +90,14 @@ export HH_CONFIG=rawhistory
 Show favorite commands by default (instead of metrics-based view):
 ```bash
 export HH_CONFIG=favorites
+```
+Flip the view so the prompt is at the bottom:
+```bash
+export HH_CONFIG=prompt-bottom
+```
+Choose a minimal layout (currently this just removes the help bar):
+```bash
+export HH_CONFIG=minimal
 ```
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,7 @@ AC_CHECK_HEADER(sys/ioctl.h)
 AC_CHECK_HEADER(termios.h)
 AC_CHECK_HEADER(unistd.h)
 AC_CHECK_HEADER(wchar.h)
+AC_CHECK_HEADER(assert.h)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -313,8 +313,8 @@ unsigned recalculate_max_history_items()
     int bottom = getmaxy(stdscr) - 1;
     if(hstr->promptBottom) {
         hstr->promptY = bottom--;
-        hstr->promptYHelp = hstr->showHelp ? bottom-- : LABEL_DISABLED_Y;
-        hstr->promptYStatus = bottom--;
+        hstr->promptYHelp = hstr->showHelp ? top++ : LABEL_DISABLED_Y;
+        hstr->promptYStatus = top++;
     } else {
         hstr->promptY = top++;
         hstr->promptYHelp = hstr->showHelp ? top++ : LABEL_DISABLED_Y;

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -296,6 +296,7 @@ void hstr_init()
     hstr->interactive=true;
     hstr->unique=true;
     hstr->showHelp = true;
+    hstr->promptBottom = false;
 
     hstr->theme=HH_THEME_MONO;
     hstr->bigKeys=RADIX_BIG_KEYS_SKIP;
@@ -328,73 +329,53 @@ unsigned recalculate_max_history_items()
 
 void hstr_get_env_configuration(Hstr *hstr)
 {
-    char *hstr_config=getenv(HH_ENV_VAR_CONFIG);
-    if(hstr_config && strlen(hstr_config)>0) {
-        if(strstr(hstr_config,HH_CONFIG_THEME_MONOCHROMATIC)) {
-            hstr->theme=HH_THEME_MONO;
-        } else {
-            if(strstr(hstr_config,HH_CONFIG_THEME_HICOLOR)) {
-                hstr->theme=HH_THEME_DARK;
-            }
-        }
-        if(strstr(hstr_config,HH_CONFIG_CASE)) {
-            hstr->caseSensitive=HH_CASE_SENSITIVE;
-        }
-        if(strstr(hstr_config,HH_CONFIG_REGEXP)) {
-            hstr->historyMatch=HH_MATCH_REGEXP;
-        } else {
-            if(strstr(hstr_config,HH_CONFIG_SUBSTRING)) {
-                hstr->historyMatch=HH_MATCH_SUBSTRING;
-            } else {
-                if(strstr(hstr_config, HH_CONFIG_KEYWORDS)) {
-                    hstr->historyMatch=HH_MATCH_KEYWORDS;
-                }
-            }
-        }
-        if(strstr(hstr_config,HH_CONFIG_SORTING)) {
-            hstr->historyView=HH_VIEW_HISTORY;
-        } else {
-            if(strstr(hstr_config,HH_CONFIG_FAVORITES)) {
-                hstr->historyView=HH_VIEW_FAVORITES;
-            }
-        }
-        if(strstr(hstr_config,HH_CONFIG_BIG_KEYS_EXIT)) {
-            hstr->bigKeys=RADIX_BIG_KEYS_EXIT;
-        } else {
-            if(strstr(hstr_config,HH_CONFIG_BIG_KEYS_FLOOR)) {
-                hstr->bigKeys=RADIX_BIG_KEYS_FLOOR;
-            } else {
-                hstr->bigKeys=RADIX_BIG_KEYS_SKIP;
-            }
-        }
-        if(strstr(hstr_config,HH_CONFIG_BLACKLIST)) {
-            hstr->blacklist.useFile=true;
-        }
-
-        if(strstr(hstr_config,HH_CONFIG_DEBUG)) {
-            hstr->debugLevel=HH_DEBUG_LEVEL_DEBUG;
-        } else {
-            if(strstr(hstr_config,HH_CONFIG_WARN)) {
-                hstr->debugLevel=HH_DEBUG_LEVEL_WARN;
-            }
-        }
-
-        if(strstr(hstr_config,HH_CONFIG_DUPLICATES)) {
-            hstr->unique=false;
-        }
-
-        if(strstr(hstr_config,HH_CONFIG_PROMPT_BOTTOM)) {
-            hstr->promptBottom = true;
-        } else {
-            hstr->promptBottom = false;
-        }
-
-        if(strstr(hstr_config,HH_CONFIG_MINIMAL)) {
-            hstr->showHelp=false;
-        }
-
-        recalculate_max_history_items();
+    const char *hstr_config=getenv(HH_ENV_VAR_CONFIG);
+    if (!hstr_config || !strlen(hstr_config)) {
+        return;
     }
+    size_t const len = strlen(hstr_config)+1;
+    char* config_items = malloc(len);
+    memcpy(config_items, hstr_config, len);
+    char* saveptr = config_items;
+    char* item;
+    while ((item = strtok_r(saveptr, ",", &saveptr)) != NULL) {
+        if(strcmp(item,HH_CONFIG_THEME_MONOCHROMATIC)==0) {
+            hstr->theme=HH_THEME_MONO;
+        } else if(strcmp(item,HH_CONFIG_THEME_HICOLOR)==0) {
+            hstr->theme=HH_THEME_DARK;
+        } else if(strcmp(item,HH_CONFIG_CASE)==0) {
+            hstr->caseSensitive=HH_CASE_SENSITIVE;
+        } else if(strcmp(item,HH_CONFIG_REGEXP)==0) {
+            hstr->historyMatch=HH_MATCH_REGEXP;
+        } else if(strcmp(item,HH_CONFIG_SUBSTRING)==0) {
+            hstr->historyMatch=HH_MATCH_SUBSTRING;
+        } else if(strcmp(item, HH_CONFIG_KEYWORDS)==0) {
+            hstr->historyMatch=HH_MATCH_KEYWORDS;
+        } else if(strcmp(item,HH_CONFIG_SORTING)==0) {
+            hstr->historyView=HH_VIEW_HISTORY;
+        } else if(strcmp(item,HH_CONFIG_FAVORITES)==0) {
+            hstr->historyView=HH_VIEW_FAVORITES;
+        } else if(strcmp(item,HH_CONFIG_BIG_KEYS_EXIT)==0) {
+            hstr->bigKeys=RADIX_BIG_KEYS_EXIT;
+        } else if(strcmp(item,HH_CONFIG_BIG_KEYS_FLOOR)==0) {
+            hstr->bigKeys=RADIX_BIG_KEYS_FLOOR;
+        } else if(strcmp(item,HH_CONFIG_BLACKLIST)==0) {
+            hstr->blacklist.useFile=true;
+        } else if(strcmp(item,HH_CONFIG_DEBUG)==0) {
+            hstr->debugLevel=HH_DEBUG_LEVEL_DEBUG;
+        } else if(strcmp(item,HH_CONFIG_WARN)==0) {
+            hstr->debugLevel=HH_DEBUG_LEVEL_WARN;
+        } else if(strcmp(item,HH_CONFIG_DUPLICATES)==0) {
+            hstr->unique=false;
+        } else if(strcmp(item,HH_CONFIG_PROMPT_BOTTOM)==0) {
+            hstr->promptBottom = true;
+        } else if(strcmp(item,HH_CONFIG_MINIMAL)==0) {
+            hstr->showHelp=false;
+        } else {
+            fprintf(stderr, "WARNING: unknown item in %s: %s\n", HH_ENV_VAR_CONFIG, item);
+        }
+    }
+    free(config_items);
 }
 
 int print_prompt()


### PR DESCRIPTION
Take all this with a grain of salt. If any is useful, cherry pick away. The most useful patch I think is the selectionCursorPosition one, which I'm hoping fixes #185. However I'm sure there are features I haven't tested.

My preference for moving status messages into the one line, optionally removing the help line and shifting both to the top for prompt-bottom are pretty drastic and not covered by config options. Just a suggestion.

