### PR TITLE
Fix of Debian installation directions

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -57,7 +57,7 @@ trust [GPG key](https://www.mindforger.com/gpgpubkey.txt) and install HSTR:
 
 ```bash
 # add PPA to APT sources:
-sudo echo -e "\ndeb https://www.mindforger.com/debian stretch main" >> /etc/apt/sources.list
+sudo bash -c 'echo -e "\ndeb https://www.mindforger.com/debian stretch main" >> /etc/apt/sources.list.d/mindforger.list'
 
 # import PPA's GPG key
 wget -qO - https://www.mindforger.com/gpgpubkey.txt | sudo apt-key add -
@@ -65,7 +65,7 @@ wget -qO - https://www.mindforger.com/gpgpubkey.txt | sudo apt-key add -
 # update sources
 sudo apt update
 
-# install MindForger
+# install HSTR
 sudo apt install hstr
 ```
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -57,7 +57,7 @@ trust [GPG key](https://www.mindforger.com/gpgpubkey.txt) and install HSTR:
 
 ```bash
 # add PPA to APT sources:
-sudo bash -c 'echo -e "\ndeb https://www.mindforger.com/debian stretch main" >> /etc/apt/sources.list.d/mindforger.list'
+sudo bash -c 'echo -e "\ndeb https://www.mindforger.com/debian stretch main" > /etc/apt/sources.list.d/mindforger.list'
 
 # import PPA's GPG key
 wget -qO - https://www.mindforger.com/gpgpubkey.txt | sudo apt-key add -


### PR DESCRIPTION
FD redirection (i.e., `>` and `>>`) is done at the shell level, not the application level. Therefore, `sudo echo foo > /etc/bar` will fail, as the shell isn't being elevated by `sudo`. The solution is to run the command inside an elevated shell, a la, `sudo bash -c 'echo foo > /etc/bar'`.

This commit wraps the command to add the repository to `/etc/apt/sources.list` as shown above.

Additionally, my change adds the repository to its own file, which is a best practice as it prevents cluttering the `sources.list` file.

Lastly, I corrected a comment.