### PR TITLE
Fix build fails on linux

### DIFF
--- a/src/include/hstr.h
+++ b/src/include/hstr.h
@@ -26,7 +26,7 @@
 #elif defined(__FreeBSD__)
   #include <ncurses.h>
 #else
-  #include <ncursesw/curses.h>
+  #include <ncurses.h>
 #endif
 #include <readline/chardefs.h>
 #include <signal.h>

--- a/src/include/hstr_curses.h
+++ b/src/include/hstr_curses.h
@@ -24,7 +24,7 @@
 #elif defined(__FreeBSD__)
 #include <ncurses.h>
 #else
-#include <ncursesw/curses.h>
+#include <ncurses.h>
 #endif
 
 #define color_attr_on(C) if(terminal_has_colors()) { attron(C); }


### PR DESCRIPTION
Before this change, errors had been thrown that `ncursesw/curses.h` is
not found etc.

This change fixes it (I've now successfully build this on my arch linux
setup)

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>