### PR TITLE
Update INSTALLATION.md with correct Homebrew formula hstr

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -142,10 +142,10 @@ To install HSTR on Haiku OS use [Haiku Depot](https://www.haiku-os.org/docs/user
 
 [Configure](CONFIGURATION.md) HSTR and check its [man page](README.md#documentation).
 ## macOS
-Install HSTR on macOS using [Homebrew](https://brew.sh/) ([formula](https://formulae.brew.sh/formula/hh)):
+Install HSTR on macOS using [Homebrew](https://brew.sh/) ([formula](https://formulae.brew.sh/formula/hstr)):
 
 ```bash
-brew install hh
+brew install hstr
 ```
 
 [Configure](CONFIGURATION.md) HSTR and check its [man page](README.md#documentation).


### PR DESCRIPTION
Hello! I noticed that the correct Homebrew formula now points to https://formulae.brew.sh/formula/hstr. I updated the INSTALLATION readme.