### PR TITLE
Add -ltinfo to LIBS variable in hstr.pro

### DIFF
--- a/hstr.pro
+++ b/hstr.pro
@@ -28,7 +28,7 @@ CONFIG -= app_bundle
 CONFIG -= qt
 
 # -L for where to look for library, -l for linking the library
-LIBS += -lm -lreadline -lncursesw
+LIBS += -lm -lreadline -lncursesw -ltinfo
 
 SOURCES += \
     src/hashset.c \


### PR DESCRIPTION
When building in an Amazon Linux AMI from the tarball, the `make` command failed with error:
> undefined reference to symbol 'keypad', 

which is part of the libtinfo5.so.

By adding -ltinfo to the libraries this was solved and the application could be built and used successfully.