### PR TITLE
Fix for subshell mode.

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -110,6 +110,15 @@ alias hh=hstr
 ```
 
 Don't forget to source `~/.bashrc` to be able to to use `hh` command.
+
+
+## Environment variables
+- `HISTFILE` (defaults to `~/.bash_history` or `~/.zsh_history`)
+- `HSTR_PROMPT` (defaults to `<user>@<hostname>$ `)
+- `HSTR_IS_SUBSHELL` (when HSTR is used in a subshell, set to `1` to fix output when pressing `TAB` or `RIGHT` arrow key)
+- `HSTR_CONFIG` (see below)
+
+
 ## Colors
 Let HSTR to use colors:
 

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -67,6 +67,7 @@
 
 #define HSTR_ENV_VAR_CONFIG      "HSTR_CONFIG"
 #define HSTR_ENV_VAR_PROMPT      "HSTR_PROMPT"
+#define HSTR_ENV_VAR_IS_SUBSHELL "HSTR_IS_SUBSHELL"
 
 #define HSTR_CONFIG_THEME_MONOCHROMATIC   "monochromatic"
 #define HSTR_CONFIG_THEME_HICOLOR         "hicolor"
@@ -1082,6 +1083,12 @@ void loop_to_select(void)
 {
     signal(SIGINT, signal_callback_handler_ctrl_c);
 
+    bool isSubshellHint=FALSE;
+    char* isSubshellHintText = getenv(HSTR_ENV_VAR_IS_SUBSHELL);
+    if(isSubshellHintText && strlen(isSubshellHintText)>0) {
+        isSubshellHint=TRUE;
+    }
+
     hstr_curses_start();
     // TODO move the code below to hstr_curses
     color_init_pair(HSTR_COLOR_NORMAL, -1, -1);
@@ -1405,7 +1412,12 @@ void loop_to_select(void)
             break;
         case K_TAB:
         case KEY_RIGHT:
-            editCommand=TRUE;
+            if(!isSubshellHint) {
+                editCommand=TRUE;
+            } else {
+                // Not setting editCommand to TRUE here,
+                // because else an unnecessary blank line gets emitted before returning to prompt.
+            }
             if(selectionCursorPosition!=SELECTION_CURSOR_IN_PROMPT) {
                 result=getResultFromSelection(selectionCursorPosition, hstr, result);
                 if(hstr->view==HSTR_VIEW_FAVORITES) {


### PR DESCRIPTION
If we run HSTR like this:

```bash
run_hstr() {
    local offset=${READLINE_POINT}
    { READLINE_LINE=$(</dev/tty HSTR_CONFIG="$HSTR_CONFIG" hstr "$@" -- ${READLINE_LINE:0:offset} 2>&1 1>&$hstrout); } {hstrout}>&1
    exec {hstrout}>&-
}
if [[ $- =~ .*i.* ]]; then bind -x '"\C-r": "run_hstr"'; fi
```

to let the terminal behave like using the classic `CTRL+R`, i.e. not printing anything but the choosen command itself. Then when the `TAB` key (or the `RIGHT` arrow key) is pressed, a blank line gets emitted before returning to the prompt.

With this pull request we can work around this issue by setting `HSTR_IS_SUBSHELL=1` when executing `hstr`. This will slightly change the behavior when pressing one of the keys mentioned above.