### PR TITLE
Fix string overflow warning

### DIFF
--- a/src/hstr_utils.c
+++ b/src/hstr_utils.c
@@ -217,7 +217,7 @@ char *get_shell_name_by_ppid(const int pid)
           shell=strrchr(shell,'/');
           if(shell != NULL) {
               shell++;
-              strncpy(name,shell,sizeof(char)*strlen(shell));
+              strncpy(name,shell,sizeof(char)*PID_BUFFER_SIZE);
           }
       }
     }


### PR DESCRIPTION
With GCC 9.2 the following warning is emitted when building hstr:
In file included from /usr/include/string.h:494,
                 from include/hstr_utils.h:26,
                 from hstr_utils.c:19:
In function ‘strncpy’,
    inlined from ‘get_shell_name_by_ppid’ at hstr_utils.c:220:15:
/usr/include/bits/string_fortified.h:106:10: warning: \
‘__builtin___strncpy_chk’ output truncated before terminating nul \
copying as many bytes from a string as its length [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
hstr_utils.c: In function ‘get_shell_name_by_ppid’:
hstr_utils.c:220:47: note: length computed here
  220 |               strncpy(name,shell,sizeof(char)*strlen(shell));
      |                                               ^~~~~~~~~~~~~

By using the destination buffer size as the number of characters to
copy this warning is avoided.