### PR TITLE
Improve zsh extended history parsing

### DIFF
--- a/src/include/hstr_history.h
+++ b/src/include/hstr_history.h
@@ -36,8 +36,7 @@
 #define FILE_ZSH_HISTORY ".zsh_history"
 #define FILE_ZSH_ZHISTORY ".zhistory"
 
-#define ZSH_HISTORY_ITEM_OFFSET 15
-#define BASH_HISTORY_ITEM_OFFSET 0
+#define ZSH_HISTORY_EXT_DIGITS 10
 
 typedef struct {
     // ranked history
@@ -48,6 +47,7 @@ typedef struct {
     unsigned rawCount;
 } HistoryItems;
 
+char* parse_history_line(char *l);
 HistoryItems* prioritized_history_create(int optionBigKeys, HashSet* blacklist);
 void prioritized_history_destroy(HistoryItems* h);
 

--- a/test/hstr-unit-tests.pro
+++ b/test/hstr-unit-tests.pro
@@ -18,6 +18,7 @@ TEMPLATE = app
 CONFIG += console
 CONFIG -= app_bundle
 CONFIG -= qt
+QMAKE_CFLAGS += -DHSTR_TESTS_UNIT
 
 # includes
 INCLUDEPATH += unity/src/c

--- a/test/src/test.c
+++ b/test/src/test.c
@@ -16,6 +16,8 @@
  limitations under the License.
 */
 
+#define HSTR_TESTS_UNIT 1
+
 #include <string.h>
 #include <regex.h>
 #include <stdio.h>
@@ -27,6 +29,7 @@
 
 #include "../../src/include/hashset.h"
 #include "../../src/include/hstr_utils.h"
+#include "../../src/include/hstr_history.h"
 #include "../../src/include/hstr_favorites.h"
 #include "../../src/include/hstr.h"
 
@@ -332,4 +335,22 @@ void test_string_elide()
     hstr_strelide(buffer, "0123456789", 8);
     TEST_ASSERT_EQUAL_STRING("012...89", buffer);
     printf("%s\n", buffer);
+}
+
+void test_parse_history_line()
+{
+    TEST_ASSERT_EQUAL(NULL, parse_history_line(NULL));
+
+    TEST_ASSERT_EQUAL_STRING("ls", parse_history_line("ls"));
+    TEST_ASSERT_EQUAL_STRING(":::", parse_history_line(":::"));
+
+    TEST_ASSERT_EQUAL_STRING(":vspman epoll_ctl", parse_history_line(": 1592444398:0;:vspman epoll_ctl"));
+    TEST_ASSERT_EQUAL_STRING("scan-view work/scans/2020-07-30-114451-3063582-1", parse_history_line(": 1596135828:6109;scan-view work/scans/2020-07-30-114451-3063582-1"));
+    TEST_ASSERT_EQUAL_STRING(":wq", parse_history_line(": 1592444398:0;:wq"));
+    TEST_ASSERT_EQUAL_STRING(":wq", parse_history_line(":wq"));
+
+    TEST_ASSERT_EQUAL_STRING(": 159244439:0;:wq", parse_history_line(": 159244439:0;:wq"));
+    TEST_ASSERT_EQUAL_STRING(": 1592444398:;:wq", parse_history_line(": 1592444398:;:wq"));
+    TEST_ASSERT_EQUAL_STRING(": 1592444398:0:wq", parse_history_line(": 1592444398:0:wq"));
+    TEST_ASSERT_EQUAL_STRING(":1592444398:0;:vspman epoll_ctl", parse_history_line(":1592444398:0;:vspman epoll_ctl"));
 }

--- a/test/src/test_runner.c
+++ b/test/src/test_runner.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include "../../src/include/hashset.h"
 #include "../../src/include/hstr_utils.h"
+#include "../../src/include/hstr_history.h"
 #include "../../src/include/hstr_favorites.h"
 #include "../../src/include/hstr.h"
 #include <string.h>
@@ -50,6 +51,7 @@ extern void test_regexp(void);
 extern void test_help_long(void);
 extern void test_help_short(void);
 extern void test_string_elide();
+extern void test_parse_history_line();
 
 
 /*=======Suite Setup=====*/
@@ -84,16 +86,17 @@ int main(void)
 {
   suite_setup();
   UnityBegin("../test/src/test.c");
-  RUN_TEST(test_args, 46);
-  RUN_TEST(test_getopt, 79);
-  RUN_TEST(test_locate_char_in_string_overflow, 162);
-  RUN_TEST(test_favorites, 173);
-  RUN_TEST(test_hashset_blacklist, 197);
-  RUN_TEST(test_hashset_get_keys, 212);
-  RUN_TEST(test_regexp, 233);
-  RUN_TEST(test_help_long, 273);
-  RUN_TEST(test_help_short, 289);
-  RUN_TEST(test_string_elide, 305);
+  RUN_TEST(test_args, 49);
+  RUN_TEST(test_getopt, 82);
+  RUN_TEST(test_locate_char_in_string_overflow, 165);
+  RUN_TEST(test_favorites, 176);
+  RUN_TEST(test_hashset_blacklist, 200);
+  RUN_TEST(test_hashset_get_keys, 215);
+  RUN_TEST(test_regexp, 236);
+  RUN_TEST(test_help_long, 276);
+  RUN_TEST(test_help_short, 292);
+  RUN_TEST(test_string_elide, 308);
+  RUN_TEST(test_parse_history_line, 340);
 
   return suite_teardown(UnityEnd());
 }


### PR DESCRIPTION
This patch fixes a segfault when .zsh_history contains commands starting with `:` and longer than 15 characters long.

Considering the history line:

    : 1592444398:0;:vspman epoll_ctl

The ranked item's line will be:

    :vspman epoll_ctl

When building the prioritized history, we used to apply the zsh extended history offset if the line starts with `:` (and if the command is longer than `15`, defined by `ZSH_HISTORY_ITEM_OFFSET`), which then makes the item point to:

    tl

This makes the `r->item` pointer invalid, which causes the segfault observed in #408 within `prioritized_history_destroy`.

---

This patch prevents the same issue from arising again (even if the line is wrongly interpreted) since it avoids any pointer arithmetic between assignment and freeing.

Additionally, the patch also greatly improves the heuristics used in determining whether a line is of extended history format or not, since the non-extended format is also supported by zsh.