### PR TITLE
Fix a potential buffer overflow in 'get_shell_name_by_ppid'

### DIFF
--- a/src/hstr_utils.c
+++ b/src/hstr_utils.c
@@ -217,7 +217,9 @@ char *get_shell_name_by_ppid(const int pid)
           shell=strrchr(shell,'/');
           if(shell != NULL) {
               shell++;
-              strncpy(name,shell,sizeof(char)*strlen(shell));
+              unsigned len=strlen(shell)*sizeof(char);
+              name = realloc(name, len);
+              strncpy(name, shell, len);
           }
       }
     }


### PR DESCRIPTION
gcc-10 shows the following warning prior to this patch:

    hstr_utils.c: In function ‘get_shell_name_by_ppid’
    hstr_utils.c:220:15: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
      220 |               strncpy(name,shell,sizeof(char)*strlen(shell));
          |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    hstr_utils.c:220:47: note: length computed here
      220 |               strncpy(name,shell,sizeof(char)*strlen(shell));
          |                                               ^~~~~~~~~~~~~