### PR TITLE
unmetafy unicode when zsh

### DIFF
--- a/src/hstr_history.c
+++ b/src/hstr_history.c
@@ -164,6 +164,9 @@ HistoryItems* prioritized_history_create(int optionBigKeys, HashSet *blacklist)
             } else {
                 line=historyList[i]->line;
             }
+            if (isZsh) {
+                line = zsh_unmetafy(line, NULL);
+            }
             rawHistory[rawOffset]=line;
             if(hashset_contains(blacklist, line)) {
                 continue;

--- a/src/hstr_utils.c
+++ b/src/hstr_utils.c
@@ -232,3 +232,17 @@ bool isZshParentShell(void) {
     free(cmdline);
     return result;
 }
+
+/* from zsh utils.c https://github.com/zsh-users/zsh/blob/master/Src/utils.c#L4922 */
+char *zsh_unmetafy(char *s, int *len)
+{
+  char *p, *t;
+
+  for (p = s; *p && *p != ZSH_META; p++);
+  for (t = p; (*t = *p++);)
+    if (*t++ == ZSH_META)
+      t[-1] = *p++ ^ 32;
+  if (len)
+    *len = t - s;
+  return s;
+}

--- a/src/include/hstr_utils.h
+++ b/src/include/hstr_utils.h
@@ -31,6 +31,7 @@
 #define ENV_VAR_HOME "HOME"
 
 #define UNUSED_ARG(expr) do { (void)(expr); } while (0)
+#define ZSH_META ((char) 0x83)
 
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
@@ -48,5 +49,6 @@ void get_hostname(int bufferSize, char* buffer);
 char* get_home_file_path(char* filename);
 void toggle_case(char* str, bool lowercase);
 bool isZshParentShell(void);
+char *zsh_unmetafy(char *s, int *len);
 
 #endif


### PR DESCRIPTION
I find this [issue](https://github.com/dvorka/hstr/issues/223). Finally I find this [mail](https://www.zsh.org/mla/users/2011/msg00154.html), then I know that:

> This isn't a bug, the history file is saved in metafied format.

the `unmetafy` code is from [zsh code](https://github.com/zsh-users/zsh/blob/master/Src/utils.c#L4921-L4933)