### PR TITLE
do not call isZshParentShell for every history line

### DIFF
--- a/src/hstr_history.c
+++ b/src/hstr_history.c
@@ -101,9 +101,17 @@ bool is_hist_timestamp(const char* line)
 
 char* parse_history_line(char *l)
 {
+#ifndef HSTR_TESTS_UNIT
+    static bool isZsh, c;
+    if(!c) {
+        isZsh=isZshParentShell();
+        c=true;
+    }
+#endif
+
     if(
 #ifndef HSTR_TESTS_UNIT
-    !isZshParentShell() ||
+    !isZsh ||
 #endif
     !l ||
     l[0]!=':') {


### PR DESCRIPTION
The zsh change in https://github.com/dvorka/hstr/commit/5ab82058592b1875e8b653a621be698087abd85a made startup of hstr significantly slower than it was in v2.2, going from almost instantaneously listing recent history to a 1-2 seconds wait after hitting CTRL+R.  This is particularly noticeable with a large `HISTFILESIZE`.  The slowdown seems to be from the `isZshParentShell` call for every history line in `parse_history_line`.  https://github.com/dvorka/hstr/blob/5ab82058592b1875e8b653a621be698087abd85a/src/hstr_history.c#L102-L106

called from `prioritized_history_create`:

https://github.com/dvorka/hstr/blob/5ab82058592b1875e8b653a621be698087abd85a/src/hstr_history.c#L171-L182

This PR adds a `isZsh bool` input argument to `parse_history_line` to prevent repeated calls to the expensive `isZshParentShell` function.  It was only checked once in `prioritized_history_create` prior to https://github.com/dvorka/hstr/commit/5ab82058592b1875e8b653a621be698087abd85a as well (https://github.com/dvorka/hstr/commit/5ab82058592b1875e8b653a621be698087abd85a#diff-258da76bc59b38c71c18642eba6ab2c8d4d8e63636d069002ff59e3d7f7f1b2cL123-L124)