### PR TITLE
Ensure 'skip-favorites-comments' does not strip comments when adding a new favorite.

### DIFF
--- a/src/hstr.c
+++ b/src/hstr.c
@@ -832,8 +832,8 @@ unsigned hstr_make_selection(char* prefix, HistoryItems* history, unsigned maxSe
         count=history->rawCount;
         break;
     case HSTR_VIEW_FAVORITES:
-        source=hstr->favorites->items;
-        count=hstr->favorites->count;
+        source=hstr->favorites->itemsView;
+        count=hstr->favorites->countView;
         break;
     case HSTR_VIEW_RANKING:
     default:

--- a/src/include/hstr.h
+++ b/src/include/hstr.h
@@ -21,13 +21,6 @@
 
 #include <getopt.h>
 #include <locale.h>
-#ifdef __APPLE__
-  #include <curses.h>
-#elif defined(__FreeBSD__)
-  #include <ncurses.h>
-#else
-  #include <ncursesw/curses.h>
-#endif
 #include <readline/chardefs.h>
 #include <signal.h>
 #include <termios.h>

--- a/src/include/hstr_favorites.h
+++ b/src/include/hstr_favorites.h
@@ -27,7 +27,9 @@
 
 typedef struct {
     char** items;
+    char** itemsView;
     unsigned count;
+    unsigned countView;
     bool loaded;
     bool reorderOnChoice;
     bool skipComments;


### PR DESCRIPTION
With this option enabled, adding a new favorite will strip the comments out. Tracking my `.hstr_favorites` file in git, I thought I could live with this quirk (`git add -p` to commit the new favorite and `git reset` to retrieve the comments), but it got old...

In this patch I separated the view from the actual raw favorites list. I hope that's fine.