### PR TITLE
Fix a memory leak in blacklist component

### DIFF
--- a/src/hstr_blacklist.c
+++ b/src/hstr_blacklist.c
@@ -78,13 +78,12 @@ void blacklist_load(Blacklist *blacklist)
                     while (p!=NULL) {
                         p=strchr(p+1,'\n');
                     }
-                    char *pb=fileContent, *pe, *s;
+                    char *pb=fileContent, *pe;
                     pe=strchr(fileContent, '\n');
                     while(pe!=NULL) {
                         *pe=0;
                         if(!hashset_contains(blacklist->set,pb)) {
-                            s=hstr_strdup(pb);
-                            hashset_add(blacklist->set,s);
+                            hashset_add(blacklist->set,pb);
                         }
                         pb=pe+1;
                         pe=strchr(pb, '\n');
@@ -151,8 +150,10 @@ void blacklist_destroy(Blacklist *blacklist, bool freeBlacklist)
                             exit(EXIT_FAILURE);
                         }
                     }
+                    free(keys[i]);
                 }
                 fclose(outputFile);
+                free(keys);
             } else {
                 if(access(fileName, F_OK) != -1) {
                     FILE *outputFile = fopen(fileName, "wb");

--- a/src/hstr_blacklist.c
+++ b/src/hstr_blacklist.c
@@ -74,10 +74,6 @@ void blacklist_load(Blacklist *blacklist)
                 fileContent[fileSize] = 0;
 
                 if(fileContent && strlen(fileContent)) {
-                    char *p=strchr(fileContent,'\n');
-                    while (p!=NULL) {
-                        p=strchr(p+1,'\n');
-                    }
                     char *pb=fileContent, *pe;
                     pe=strchr(fileContent, '\n');
                     while(pe!=NULL) {


### PR DESCRIPTION
Detected by Valgrind:

    ==17478== HEAP SUMMARY:
    ==17478==     in use at exit: 394,555 bytes in 455 blocks
    ==17478==   total heap usage: 7,453 allocs, 6,998 frees, 2,161,983 bytes allocated
    ==17478==
    ==17478== 58 bytes in 16 blocks are definitely lost in loss record 10 of 50
    ==17478==    at 0x483A77F: malloc (vg_replace_malloc.c:307)
    ==17478==    by 0x10B74A: hstr_strdup (hstr_utils.c:35)
    ==17478==    by 0x10C593: blacklist_load (hstr_blacklist.c:86)
    ==17478==    by 0x1107B3: hstr_main (hstr.c:1736)
    ==17478==    by 0x4AA3151: (below main) (in /usr/lib/libc-2.32.so)
    ==17478==
    ==17478== 186 (128 direct, 58 indirect) bytes in 1 blocks are definitely lost in loss record 18 of 50
    ==17478==    at 0x483A77F: malloc (vg_replace_malloc.c:307)
    ==17478==    by 0x10A8FE: hashset_keys (hashset.c:108)
    ==17478==    by 0x10C76F: blacklist_destroy (hstr_blacklist.c:142)
    ==17478==    by 0x10D482: hstr_destroy (hstr.c:385)
    ==17478==    by 0x10D4D7: hstr_exit (hstr.c:394)
    ==17478==    by 0x10D4FC: signal_callback_handler_ctrl_c (hstr.c:403)
    ==17478==    by 0x10D4FC: signal_callback_handler_ctrl_c (hstr.c:398)
    ==17478==    by 0x4AB869F: ??? (in /usr/lib/libc-2.32.so)
    ==17478==    by 0x4B6BEBF: read (in /usr/lib/libc-2.32.so)
    ==17478==    by 0x4A296EF: _nc_wgetch (in /usr/lib/libncursesw.so.6.2)
    ==17478==    by 0x4A2A058: wgetch (in /usr/lib/libncursesw.so.6.2)
    ==17478==    by 0x10F73B: loop_to_select (hstr.c:1280)
    ==17478==    by 0x1105B1: hstr_interactive (hstr.c:1658)
    ==17478==
    ==17478== LEAK SUMMARY:
    ==17478==    definitely lost: 186 bytes in 17 blocks
    ==17478==    indirectly lost: 58 bytes in 16 blocks
    ==17478==      possibly lost: 0 bytes in 0 blocks
    ==17478==    still reachable: 394,311 bytes in 422 blocks
    ==17478==         suppressed: 0 bytes in 0 blocks