### PR TITLE
src/hstr.c: always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/hstr.c
+++ b/src/hstr.c
@@ -740,7 +740,7 @@ void print_cmd_added_favorite_label(const char* cmd)
         color_attr_on(COLOR_PAIR(HSTR_COLOR_INFO));
         color_attr_on(A_BOLD);
     }
-    mvprintw(hstr->promptYNotification, 0, screenLine);
+    mvprintw(hstr->promptYNotification, 0, "%s", screenLine);
     if(hstr->theme & HSTR_THEME_COLOR) {
         color_attr_off(A_BOLD);
         color_attr_on(COLOR_PAIR(HSTR_COLOR_NORMAL));


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    hstr.c:743:44: error: format not a string literal and no format arguments [-Werror=format-security]
      743 |     mvprintw(hstr->promptYNotification, 0, screenLine);
          |                                            ^~~~~~~~~~

Let's wrap all the missing places with "%s" format.