### PR TITLE
HSTR release 2.5.0

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+2021-12-13  Martin Dvorak  <martin.dvorak@mindforger.com>
+
+  * Released v2.5.0 - minor fix release to fix Arch build.
+
 2021-12-03  Martin Dvorak  <martin.dvorak@mindforger.com>
 
   * Released v2.4.0 - ability to insert custom command to terminal prompt,

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -98,7 +98,7 @@ Alternatively you can download and install `.deb` archive from [GitHub releases]
 section of the project:
 
 ```bash
-wget -O hstr.deb https://github.com/dvorka/hstr/releases/download/2.4/hstr_<major>.<minor>.<revision>-1_amd64.deb
+wget -O hstr.deb https://github.com/dvorka/hstr/releases/download/<major>.<minor>/hstr_<major>.<minor>.<revision>-1_amd64.deb
 
 # dependencies:
 apt-get install libncursesw5 libtinfo5
@@ -191,7 +191,7 @@ pkg install hstr
 To install HSTR on Slackware, please check [pkgs.org](https://pkgs.org/search/?q=hstr). You can install HSTR as follows:
 
 ```bash
-upgradepkg --install-new hstr-2.4-x86_64-1cf.txz
+upgradepkg --install-new hstr-<major>.<minor>-x86_64-1cf.txz
 ```
 
 [Configure](CONFIGURATION.md) HSTR and check its [man page](README.md#documentation).

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@
 # Contributor: Busindre <busilezas at busindre.com>
 
 pkgname=hstr
-pkgver=2.3
+pkgver=2.5
 pkgrel=1
 pkgdesc="A command line utility that brings improved BASH command completion from the history. It aims to make completion easier and more efficient than Ctrl-r."
 arch=('any')

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,7 @@ The following HSTR versions are currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 2.5.0   | :white_check_mark: |
 | 2.4.0   | :white_check_mark: |
 | <= 2.3.0   | :x:                |
 

--- a/build/debian/make-deb.sh
+++ b/build/debian/make-deb.sh
@@ -147,8 +147,8 @@ then
   exit 1
 fi
 
-export ARG_BAZAAR_MSG="HSTR 2.4.0"
-export ARG_VERSION="2.4.0"
+export ARG_BAZAAR_MSG="HSTR 2.5.0"
+export ARG_VERSION="2.5.0"
 
 # Debian releases: https://www.debian.org/releases/
 #   6/7/8/9/10: squeeze wheezy jessie stretch buster

--- a/build/fedora/rpm-from-deb.sh
+++ b/build/fedora/rpm-from-deb.sh
@@ -20,7 +20,7 @@
 # This script is available from http://www.mindforger.com/fedora/fedora-rpm-from-deb.sh
 # to be easily available in VMs
 
-export MFVERSION="2.4.0"
+export MFVERSION="2.5.0"
 export MFPRJNAME="hstr-${MFVERSION}"
 export AMD64NAME="hstr_${MFVERSION}-1_amd64"
 export I386NAME="hstr_${MFVERSION}-1_i386"

--- a/build/tarball/tarball-build.sh
+++ b/build/tarball/tarball-build.sh
@@ -20,7 +20,7 @@
 
 export SCRIPT_HOME=`pwd`
 
-export HSTR_VERSION="2.4.0"
+export HSTR_VERSION="2.5.0"
 
 export NOW=`date +%Y-%m-%d--%H-%M-%S`
 export GH_RELEASE_DIR=~/p/hstr/release

--- a/build/ubuntu/launchpad-make-all-releases.sh
+++ b/build/ubuntu/launchpad-make-all-releases.sh
@@ -163,8 +163,8 @@ then
     exit 1
 fi
 
-export ARG_BAZAAR_MSG="Release 2.4"
-export ARG_MAJOR_VERSION=2.4.
+export ARG_BAZAAR_MSG="Release 2.5"
+export ARG_MAJOR_VERSION=2.5.
 export ARG_MINOR_VERSION=7 # minor version is incremented for every Ubuntu version
 
 # https://wiki.ubuntu.com/Releases

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@
 
 AC_PREREQ([2.69])
 
-AC_INIT(hstr, 2.4.0, martin.dvorak@mindforger.com)
+AC_INIT(hstr, 2.5.0, martin.dvorak@mindforger.com)
 AC_CONFIG_FILES([Makefile src/Makefile man/Makefile])
 
 # Check src dir existence.

--- a/pad.xml
+++ b/pad.xml
@@ -51,9 +51,9 @@
 	</Company_Info>
 	<Program_Info>
 		<Program_Name>HSTR</Program_Name>
-		<Program_Version>2.4.0</Program_Version>
+		<Program_Version>2.5.0</Program_Version>
 		<Program_Release_Month>12</Program_Release_Month>
-		<Program_Release_Day>3</Program_Release_Day>
+		<Program_Release_Day>13</Program_Release_Day>
 		<Program_Release_Year>2021</Program_Release_Year>
 		<Program_Cost_Dollars />
 		<Program_Cost_Other_Code>USD</Program_Cost_Other_Code>

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -137,7 +137,7 @@
 
 // major.minor.revision
 static const char* VERSION_STRING=
-        "hstr version \"2.4.0\" (2021-12-03T21:30:00)"
+        "hstr version \"2.5.0\" (2021-12-13T22:00:00)"
         "\n";
 
 static const char* HSTR_VIEW_LABELS[]={
@@ -742,7 +742,7 @@ void print_cmd_added_favorite_label(const char* cmd)
         color_attr_on(COLOR_PAIR(HSTR_COLOR_INFO));
         color_attr_on(A_BOLD);
     }
-    mvprintw(hstr->promptYNotification, 0, screenLine);
+    mvprintw(hstr->promptYNotification, 0, "%s", screenLine);
     if(hstr->theme & HSTR_THEME_COLOR) {
         color_attr_off(A_BOLD);
         color_attr_on(COLOR_PAIR(HSTR_COLOR_NORMAL));


### PR DESCRIPTION
This PR brings HSTR 2.5.0 (Arch build fix of `mvprintw` #443) to `master`.

