### PR TITLE
HSTR for Bash which does not need `TIOCSTI` #478

### DIFF
--- a/hstr.pro
+++ b/hstr.pro
@@ -60,3 +60,7 @@ hstrdebug {
     QMAKE_CC = ccache gcc
 }
 QMAKE_LINK = gcc
+
+DEFINES += LINUX_KERNEL_6
+
+message(DEFINES of hstr.pro build: $$DEFINES)

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -137,7 +137,7 @@
 
 // major.minor.revision
 static const char* VERSION_STRING=
-        "hstr version \"2.6.0\" (2022-12-11T22:00:00)"
+        "hstr version \"2.7.0\" (2023-03-11T18:15:00)"
         "\n";
 
 static const char* HSTR_VIEW_LABELS[]={
@@ -190,7 +190,7 @@ static const char* INSTALL_BASH_STRING=
         "\n  READLINE_POINT=${#READLINE_LINE}"
         "\n}"
         "\nif [[ $- =~ .*i.* ]]; then bind -x '\"\\C-r\": \"hstrwsl\"'; fi"
-#elif defined(__CYGWIN__)
+#elif defined(__CYGWIN__) || defined(LINUX_KERNEL_6)
         "\nfunction hstrcygwin {"
         "\n  offset=${READLINE_POINT}"
         "\n  READLINE_POINT=0"

--- a/src/hstr_utils.c
+++ b/src/hstr_utils.c
@@ -106,7 +106,7 @@ void hstr_chop(char *s)
     }
 }
 
-#if !defined(__MS_WSL__) && !defined(__CYGWIN__) && !defined(DEBUG_NO_TIOCSTI)
+#if !defined(__MS_WSL__) && !defined(__CYGWIN__) && !defined(LINUX_KERNEL_6) && !defined(DEBUG_NO_TIOCSTI)
 void tiocsti()
 {
     char buf[] = DEFAULT_COMMAND;
@@ -120,7 +120,7 @@ void tiocsti()
 void fill_terminal_input(char* cmd, bool padding)
 {
     if(cmd && strlen(cmd)>0) {
-#if defined(__MS_WSL__) || defined(__CYGWIN__) || defined(DEBUG_NO_TIOCSTI)
+#if defined(__MS_WSL__) || defined(__CYGWIN__) || defined(LINUX_KERNEL_6) || defined(DEBUG_NO_TIOCSTI)
         fprintf(stderr, "%s", cmd);
         if(padding) fprintf(stderr, "%s", "\n");
 #else


### PR DESCRIPTION
This PR brings a `LINUX_KERNEL_6` define allowing to build a `HSTR` that does not need `TIOCSTI` syscall (`TIOCSTI` is not available in Linux kernels >=6.2.0):

* this is an experimental change which will work for `Bash` only (`zsh` is not supported yet)

In order to make it work:

1. build `HSTR` either using `qmake` (defined is set there) or use the define as your compiler parameter
2. check `hstr --show-configuration` - the command is modified and looks like:
```
# HSTR configuration - add this to ~/.bashrc
alias hh=hstr                    # hh to be alias for hstr
export HSTR_CONFIG=hicolor       # get more colors
shopt -s histappend              # append new history items to .bash_history
export HISTCONTROL=ignorespace   # leading space hides commands from history
export HISTFILESIZE=10000        # increase history file size (default is 500)
export HISTSIZE=${HISTFILESIZE}  # increase history size (default is 500)
# ensure synchronization between bash memory and history file
export PROMPT_COMMAND="history -a; history -n; ${PROMPT_COMMAND}"
# if this is interactive shell, then bind hstr to Ctrl-r (for Vi mode check doc)
function hstrcygwin {
  offset=${READLINE_POINT}
  READLINE_POINT=0
  { READLINE_LINE=$(</dev/tty hstr ${READLINE_LINE:0:offset} 2>&1 1>&$hstrout); } {hstrout}>&1
  READLINE_POINT=${#READLINE_LINE}
}
if [[ $- =~ .*i.* ]]; then bind -x '"\C-r": "hstrcygwin"'; fi
```
* **replace** your existing configuration with the above one:
```
./hstr --show-configuration >> ~/.bashrc
```

If your system already has 6.2.0+ kernel, please let me know whether this enhancement works for you. 