### PR TITLE
Update manpage and append -- to hstr calls

### DIFF
--- a/man/hstr.1
+++ b/man/hstr.1
@@ -199,8 +199,7 @@ export HISTSIZE=${HISTFILESIZE}  # increase history size (default is 500)
 # ensure synchronization between bash memory and history file
 export PROMPT_COMMAND="history -a; history -n; ${PROMPT_COMMAND}"
 function hstrnotiocsti {
-    { HSTR_OUT="$( { </dev/tty hstr ${READLINE_LINE}; } 2>&1 1>&3 3>&- )"; } 3>&1;
-    READLINE_LINE="$(hstr ${READLINE_LINE})"
+    { READLINE_LINE=\"$( { </dev/tty hstr -- ${READLINE_LINE}; } 2>&1 1>&3 3>&- )\"; } 3>&1;
     READLINE_POINT=${#READLINE_LINE}
 }
 # if this is interactive shell, then bind hstr to Ctrl-r (for Vi mode check doc)
@@ -232,7 +231,7 @@ setopt histignorespace           # skip cmds w/ leading space from history
 export HSTR_CONFIG=hicolor       # get more colors
 hstr_no_tiocsti() {
     zle -I
-    { HSTR_OUT="$( { </dev/tty hstr ${BUFFER}; } 2>&1 1>&3 3>&- )"; } 3>&1;
+    { HSTR_OUT="$( { </dev/tty hstr -- ${BUFFER}; } 2>&1 1>&3 3>&- )"; } 3>&1;
     BUFFER="${HSTR_OUT}"
     CURSOR=${#BUFFER}
     zle redisplay

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -364,7 +364,7 @@ void print_bash_install_code(void)
 #else
         "\nfunction hstrnotiocsti {"
 #endif
-        "\n    { READLINE_LINE=\"$( { </dev/tty hstr ${READLINE_LINE}; } 2>&1 1>&3 3>&- )\"; } 3>&1;"
+        "\n    { READLINE_LINE=\"$( { </dev/tty hstr -- ${READLINE_LINE}; } 2>&1 1>&3 3>&- )\"; } 3>&1;"
         "\n    READLINE_POINT=${#READLINE_LINE}"
         "\n}"
         "\n# if this is interactive shell, then bind hstr to Ctrl-r (for Vi mode check doc)"
@@ -403,7 +403,7 @@ void print_zsh_install_code(void)
 #endif
 
         "\n    zle -I"
-        "\n    { HSTR_OUT=\"$( { </dev/tty hstr ${BUFFER}; } 2>&1 1>&3 3>&- )\"; } 3>&1;"
+        "\n    { HSTR_OUT=\"$( { </dev/tty hstr -- ${BUFFER}; } 2>&1 1>&3 3>&- )\"; } 3>&1;"
         "\n    BUFFER=\"${HSTR_OUT}\""
         "\n    CURSOR=${#BUFFER}"
         "\n    zle redisplay"


### PR DESCRIPTION
Aftercare on the 3.1 release fixes for no TIOCSTI:

- Update the manpage with the fixed bash configuration
- Append `--` to hstr calls, in both the bash and zsh configurations

The latter so that typing `--help [ctrl-r]` searches history instead of
showing hstr help.

This fixes the feedback from @leapfrog on #485.
