### PR TITLE
update Nix installation instructions

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -263,7 +263,7 @@ sudo port install hstr
 To install HSTR using the [nix package manager](https://nixos.org/nix/) e.g. on [NixOS](https://nixos.org/) you can use the [nix derivation for HSTR](https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/misc/hstr/default.nix):
 
 ```bash
-nix-env -i hstr
+nix profile install nixpkgs#hstr
 ```
 
 [Configure](CONFIGURATION.md) HSTR and check its [man page](README.md#documentation).


### PR DESCRIPTION
We should avoid recommending nix-env as it will often lead to undesirable behaviour (e.g. name collisions), especially on NixOS.

Read more here: https://stop-using-nix-env.privatevoid.net/