### PR TITLE
replace show-bash-configuration with show-configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Configure HSTR just by running:
 
 ```bash
 # bash
-hstr --show-bash-configuration >> ~/.bashrc
+hstr --show-configuration >> ~/.bashrc
 
 # zsh
 hstr --show-zsh-configuration >> ~/.zshrc


### PR DESCRIPTION
 show-bash-configuration is no longer available, show-configuration is the right option to use.
