### PR TITLE
Edit the first search result if available

### DIFF
--- a/src/hstr.c
+++ b/src/hstr.c
@@ -1598,7 +1598,11 @@ void loop_to_select(void)
                     favorites_choose(hstr->favorites,result);
                 }
             } else {
-                result=pattern;
+                if (hstr->selectionSize > 0) {
+                    result=hstr->selection[0];
+                } else {
+                    result=pattern;
+                }
             }
             done=TRUE;
             break;


### PR DESCRIPTION
I often use Ctrl+R to search for commands with the intention of editing them rather than executing. Typically, I find myself wanting to edit the first command that appears in the search results. 