### PR TITLE
Document TAB edit and ENTER execute functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ again? Are you looking for a tool that is able to manage your
 **favorite** commands?
 
 HSTR (**H**i**ST**o**R**y) is a command line utility that brings improved `bash`/`zsh` command completion
-from the history. It aims to make completion **easier** and more **efficient** than <kbd>Ctrl-r</kbd>.
+from the history. It aims to make completion **easier** and more **efficient** than <kbd>Ctrl-r</kbd>. Press <kbd>TAB</kbd> to edit a selected command and <kbd>ENTER</kbd> to execute it directly.
 
 HSTR can also **manage** your command history (for instance you can remove
 commands that are obsolete or contain a piece of sensitive information)


### PR DESCRIPTION
I was initially unaware that the default Ctrl+R functionality allowed for command editing, which made the use of TAB for editing within HSTR non-intuitive for me. Consequently, I had to spend some time examining the source code to discover that commands could be edited instead of being executed immediately.