### PR TITLE
Use wide char aware `hstr_strlen()` for `promptLength`

### DIFF
--- a/src/hstr.c
+++ b/src/hstr.c
@@ -643,7 +643,7 @@ unsigned print_prompt(void)
     char *prompt = getenv(HSTR_ENV_VAR_PROMPT);
     if(prompt) {
         mvprintw(hstr->promptY, xoffset, "%s", prompt);
-        promptLength=strlen(prompt);
+        promptLength=hstr_strlen(prompt);
     } else {
         char *user = getenv(ENV_VAR_USER);
         char *hostname=malloc(HOSTNAME_BUFFER);


### PR DESCRIPTION
Calculate length of prompt correctly if `HSTR_PROMPT` contains UTF-8 characters (e.g. `'❯ '`)