### PR TITLE
fix(shell): :bug: fix unexpected double quote in Zsh

### DIFF
--- a/man/hstr.1
+++ b/man/hstr.1
@@ -232,7 +232,7 @@ setopt histignorespace           # skip cmds w/ leading space from history
 export HSTR_CONFIG=hicolor       # get more colors
 hstr_no_tiocsti() {
     zle -I
-    { HSTR_OUT="$( { </dev/tty hstr ${BUFFER}; } 2>&1 1>&3 3>&- )"; } 3>&1;
+    { HSTR_OUT="$( { echo ${BUFFER} | hstr </dev/tty } 2>&1 1>&3 3>&- )"; } 3>&1;
     BUFFER="${HSTR_OUT}"
     CURSOR=${#BUFFER}
     zle redisplay

--- a/man/hstr.1
+++ b/man/hstr.1
@@ -232,7 +232,7 @@ setopt histignorespace           # skip cmds w/ leading space from history
 export HSTR_CONFIG=hicolor       # get more colors
 hstr_no_tiocsti() {
     zle -I
-    { HSTR_OUT="$( { echo ${BUFFER} | hstr </dev/tty } 2>&1 1>&3 3>&- )"; } 3>&1;
+    { HSTR_OUT="$( { echo ${BUFFER} | hstr </dev/tty; } 2>&1 1>&3 3>&- )"; } 3>&1;
     BUFFER="${HSTR_OUT}"
     CURSOR=${#BUFFER}
     zle redisplay

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -403,7 +403,7 @@ void print_zsh_install_code(void)
 #endif
 
         "\n    zle -I"
-        "\n    { HSTR_OUT=\"$( { echo ${BUFFER} | hstr </dev/tty } 2>&1 1>&3 3>&- )\"; } 3>&1;"
+        "\n    { HSTR_OUT=\"$( { echo ${BUFFER} | hstr </dev/tty; } 2>&1 1>&3 3>&- )\"; } 3>&1;"
         "\n    BUFFER=\"${HSTR_OUT}\""
         "\n    CURSOR=${#BUFFER}"
         "\n    zle redisplay"

--- a/src/hstr.c
+++ b/src/hstr.c
@@ -403,7 +403,7 @@ void print_zsh_install_code(void)
 #endif
 
         "\n    zle -I"
-        "\n    { HSTR_OUT=\"$( { </dev/tty hstr ${BUFFER}; } 2>&1 1>&3 3>&- )\"; } 3>&1;"
+        "\n    { HSTR_OUT=\"$( { echo ${BUFFER} | hstr </dev/tty } 2>&1 1>&3 3>&- )\"; } 3>&1;"
         "\n    BUFFER=\"${HSTR_OUT}\""
         "\n    CURSOR=${#BUFFER}"
         "\n    zle redisplay"

--- a/test/sh/tiotcsi-function-zsh.sh
+++ b/test/sh/tiotcsi-function-zsh.sh
@@ -87,7 +87,7 @@ export HSTR_TIOCSTI=n
 
 hstr_no_tiocsti() {
     zle -I
-    { HSTR_OUT="$( { </dev/tty hstr ${BUFFER}; } 2>&1 1>&3 3>&- )"; } 3>&1;
+    { HSTR_OUT="$( { echo ${BUFFER} | hstr </dev/tty } 2>&1 1>&3 3>&- )"; } 3>&1;
     BUFFER="${HSTR_OUT}"
     CURSOR=${#BUFFER}
     zle redisplay

--- a/test/sh/tiotcsi-function-zsh.sh
+++ b/test/sh/tiotcsi-function-zsh.sh
@@ -87,7 +87,7 @@ export HSTR_TIOCSTI=n
 
 hstr_no_tiocsti() {
     zle -I
-    { HSTR_OUT="$( { echo ${BUFFER} | hstr </dev/tty } 2>&1 1>&3 3>&- )"; } 3>&1;
+    { HSTR_OUT="$( { echo ${BUFFER} | hstr </dev/tty; } 2>&1 1>&3 3>&- )"; } 3>&1;
     BUFFER="${HSTR_OUT}"
     CURSOR=${#BUFFER}
     zle redisplay


### PR DESCRIPTION
* Previously double quotes would be added when invoking hstr using `Ctrl+R` due to the BUFFER been passed as an argument to hstr
* Changed how hstr is invoked to pipe the BUFFER in and then continue reading from /dev/tty

Fixes #488