### PR TITLE
feat: ✨ HSTRFILE environment variable for per-process isolation

### DIFF
--- a/src/hstr_history.c
+++ b/src/hstr_history.c
@@ -47,7 +47,10 @@ unsigned history_ranking_function(unsigned rank, int newOccurenceOrder, size_t l
 
 char* get_history_file_name(void)
 {
-    char* historyFile = getenv(ENV_VAR_HISTFILE);
+    char* historyFile = getenv(ENV_VAR_HSTRFILE);
+    if(!historyFile || strlen(historyFile)==0) {
+        historyFile = getenv(ENV_VAR_HISTFILE);
+    }
     if(!historyFile || strlen(historyFile)==0) {
         if(is_zsh_parent_shell()) {
             historyFile = get_home_file_path(FILE_ZSH_HISTORY);

--- a/src/include/hstr_history.h
+++ b/src/include/hstr_history.h
@@ -30,6 +30,7 @@
 #include "radixsort.h"
 #include "hstr_favorites.h"
 
+#define ENV_VAR_HSTRFILE "HSTRFILE"
 #define ENV_VAR_HISTFILE "HISTFILE"
 
 #define FILE_DEFAULT_HISTORY ".bash_history"


### PR DESCRIPTION
Supports global hstr file and separate history file per shell.

E.g. source the following file and each bash shell will have it's own .history file per PID as well as a global. This way, each shell has it's own history (up/down arrows) which is unique to that shell; but also has access to the overall history (Ctrl-R).

(Note: these per-pid files don't get deleted presently, so that's something that needs to be considered)

[hstr_sync_example.sh](https://github.com/user-attachments/files/24555587/hstr_sync_example.sh)
