### PR TITLE
feat: add XDG Base Directory support for config files

### DIFF
--- a/src/hstr_blacklist.c
+++ b/src/hstr_blacklist.c
@@ -17,6 +17,7 @@
 */
 
 #include "include/hstr_blacklist.h"
+#include "include/hstr_utils.h"
 
 static const char *defaultCommandBlacklist[] = {
         "ls", "pwd", "cd", "cd ..", "hstr", "hh", "mc",
@@ -34,12 +35,7 @@ void blacklist_init(Blacklist *blacklist)
 
 char* blacklist_get_filename()
 {
-    char *home = getenv(ENV_VAR_HOME);
-    char *fileName = (char*) malloc(strlen(home) + 1 + strlen(FILE_HSTR_BLACKLIST) + 1);
-    strcpy(fileName, home);
-    strcat(fileName, "/");
-    strcat(fileName, FILE_HSTR_BLACKLIST);
-    return fileName;
+    return get_hstr_configuration_file_path(FILE_HSTR_BLACKLIST, "blacklist");
 }
 
 void blacklist_load_default(Blacklist* blacklist) {
@@ -132,28 +128,38 @@ void blacklist_destroy(Blacklist *blacklist, bool freeBlacklist)
             int size=hashset_size(blacklist->set);
             if(size) {
                 FILE *outputFile = fopen(fileName, "wb");
-                rewind(outputFile);
-                int i;
-                char **keys=hashset_keys(blacklist->set);
-                for(i=0; i<size; i++) {
-                    if(!fwrite(keys[i], sizeof(char), strlen(keys[i]), outputFile)) {
-                        if(ferror(outputFile)) {
-                            exit(EXIT_FAILURE);
+                if (outputFile) {
+                    rewind(outputFile);
+                    int i;
+                    char **keys=hashset_keys(blacklist->set);
+                    for(i=0; i<size; i++) {
+                        if(!fwrite(keys[i], sizeof(char), strlen(keys[i]), outputFile)) {
+                            if(ferror(outputFile)) {
+                                exit(EXIT_FAILURE);
+                            }
                         }
-                    }
-                    if(!fwrite("\n", sizeof(char), strlen("\n"), outputFile)) {
-                        if(ferror(outputFile)) {
-                            exit(EXIT_FAILURE);
+                        if(!fwrite("\n", sizeof(char), strlen("\n"), outputFile)) {
+                            if(ferror(outputFile)) {
+                                exit(EXIT_FAILURE);
+                            }
                         }
+                        free(keys[i]);
                     }
-                    free(keys[i]);
+                    fclose(outputFile);
+                    free(keys);
+                } else {
+                    // Failed to open file, but we must still free keys
+                    int i;
+                    char **keys=hashset_keys(blacklist->set);
+                    for(i=0; i<size; i++) {
+                        free(keys[i]);
+                    }
+                    free(keys);
                 }
-                fclose(outputFile);
-                free(keys);
             } else {
                 if(access(fileName, F_OK) != -1) {
                     FILE *outputFile = fopen(fileName, "wb");
-                    fclose(outputFile);
+                    if (outputFile) fclose(outputFile);
                 }
             }
             free(fileName);

--- a/src/hstr_favorites.c
+++ b/src/hstr_favorites.c
@@ -17,6 +17,7 @@
 */
 
 #include "include/hstr_favorites.h"
+#include "include/hstr_utils.h"
 
 #define FAVORITE_SEGMENT_SIZE 10
 
@@ -45,12 +46,7 @@ void favorites_show(FavoriteItems *favorites)
 
 char* favorites_get_filename()
 {
-    char* home = getenv(ENV_VAR_HOME);
-    char* fileName = (char*) malloc(strlen(home) + 1 + strlen(FILE_HSTR_FAVORITES) + 1);
-    strcpy(fileName, home);
-    strcat(fileName, "/");
-    strcat(fileName, FILE_HSTR_FAVORITES);
-    return fileName;
+    return get_hstr_configuration_file_path(FILE_HSTR_FAVORITES, "favorites");
 }
 
 void favorites_get(FavoriteItems* favorites)
@@ -114,25 +110,27 @@ void favorites_save(FavoriteItems* favorites)
 
     if(favorites->count) {
         FILE* outputFile = fopen(fileName, "wb");
-        rewind(outputFile);
-        unsigned i;
-        for(i=0; i<favorites->count; i++) {
-            if(!fwrite(favorites->items[i], sizeof(char), strlen(favorites->items[i]), outputFile)) {
-                if(ferror(outputFile)) {
-                    exit(EXIT_FAILURE);
+        if (outputFile) {
+            rewind(outputFile);
+            unsigned i;
+            for(i=0; i<favorites->count; i++) {
+                if(!fwrite(favorites->items[i], sizeof(char), strlen(favorites->items[i]), outputFile)) {
+                    if(ferror(outputFile)) {
+                        exit(EXIT_FAILURE);
+                    }
+                }
+                if(!fwrite("\n", sizeof(char), strlen("\n"), outputFile)) {
+                    if(ferror(outputFile)) {
+                        exit(EXIT_FAILURE);
+                    }
                 }
             }
-            if(!fwrite("\n", sizeof(char), strlen("\n"), outputFile)) {
-                if(ferror(outputFile)) {
-                    exit(EXIT_FAILURE);
-                }
-            }
+            fclose(outputFile);
         }
-        fclose(outputFile);
     } else {
         if(access(fileName, F_OK) != -1) {
             FILE *output_file = fopen(fileName, "wb");
-            fclose(output_file);
+            if (output_file) fclose(output_file);
         }
     }
     free(fileName);

--- a/src/hstr_utils.c
+++ b/src/hstr_utils.c
@@ -212,6 +212,63 @@ char* get_home_file_path(char* filename)
     return path;
 }
 
+char* get_hstr_configuration_file_path(const char* legacy_filename, const char* xdg_filename)
+{
+    char* home = getenv(ENV_VAR_HOME);
+    if (!home) return NULL;
+
+    // 1. check legacy file in HOME
+    char* legacy_path = malloc(strlen(home) + 1 + strlen(legacy_filename) + 1);
+    strcpy(legacy_path, home);
+    strcat(legacy_path, "/");
+    strcat(legacy_path, legacy_filename);
+
+    if (access(legacy_path, F_OK) != -1) {
+        return legacy_path;
+    }
+
+    // 2. check XDG config home
+    const char* xdg_config_home_env = getenv(ENV_VAR_XDG_CONFIG_HOME);
+    char* xdg_path_dir;
+
+    if (xdg_config_home_env && strlen(xdg_config_home_env) > 0) {
+        xdg_path_dir = malloc(strlen(xdg_config_home_env) + 1 + strlen("hstr") + 1);
+        sprintf(xdg_path_dir, "%s/hstr", xdg_config_home_env);
+    } else {
+        xdg_path_dir = malloc(strlen(home) + 1 + strlen(".config/hstr") + 1);
+        sprintf(xdg_path_dir, "%s/.config/hstr", home);
+    }
+
+    char* xdg_path = malloc(strlen(xdg_path_dir) + 1 + strlen(xdg_filename) + 1);
+    sprintf(xdg_path, "%s/%s", xdg_path_dir, xdg_filename);
+
+    if (access(xdg_path, F_OK) != -1) {
+        free(legacy_path);
+        free(xdg_path_dir);
+        return xdg_path;
+    }
+
+    // 3. default to XDG (create directory)
+    if (access(xdg_path_dir, F_OK) == -1) {
+        // attempt to create config dir (assuming .config exists or simple structure)
+        // separate mkdir calls to ensure both exist if falling back to .config
+        if (xdg_config_home_env) {
+            // Ensure parent directory exists (handle custom XDG_CONFIG_HOME case)
+            mkdir(xdg_config_home_env, 0700);
+        } else {
+            char* config_dir = malloc(strlen(home) + 1 + strlen(".config") + 1);
+            sprintf(config_dir, "%s/.config", home);
+            mkdir(config_dir, 0700);
+            free(config_dir);
+        }
+        mkdir(xdg_path_dir, 0700);
+    }
+
+    free(legacy_path);
+    free(xdg_path_dir);
+    return xdg_path;
+}
+
 void toggle_case(char *str, bool lowercase) {
     if(str && strlen(str)>0) {
         int i;

--- a/src/include/hstr_utils.h
+++ b/src/include/hstr_utils.h
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <stdlib.h>
 #include <string.h>
@@ -31,6 +32,7 @@
 #include <unistd.h>
 
 #define ENV_VAR_HOME "HOME"
+#define ENV_VAR_XDG_CONFIG_HOME "XDG_CONFIG_HOME"
 
 #define UNUSED_ARG(expr) do { (void)(expr); } while (0)
 #define ZSH_META ((char) 0x83)
@@ -93,6 +95,7 @@ void fill_terminal_input(char* cmd, bool padding);
 void reverse_char_pointer_array(char** array, unsigned length);
 void get_hostname(int bufferSize, char* buffer);
 char* get_home_file_path(char* filename);
+char* get_hstr_configuration_file_path(const char* legacy_filename, const char* xdg_filename);
 void toggle_case(char* str, bool lowercase);
 bool is_zsh_parent_shell(void);
 char* zsh_unmetafy(char* s, int* len);


### PR DESCRIPTION
## Description
Adds support for the XDG Base Directory specification.

## Changes
- Configuration files (blacklist, favorites) now default to `$XDG_CONFIG_HOME/hstr/` (usually `~/.config/hstr/`).
- Maintains backward compatibility: if `~/.hstr_favorites` or `~/.hstr_blacklist` exist, they are used instead of XDG paths.
- Automatically creates the configuration directory structure if it doesn't exist.

## Testing
Verified in a clean Arch Linux chroot:
- [x] Detected legacy files when present.
- [x] Created `~/.config/hstr/` when no legacy files existed.
- [x] Respected custom `XDG_CONFIG_HOME` environment variable.

## Disclaimer
I did use Google Gemini 3 for assistance during this. I noticed this program had an old issue (#461), and I highly prefer a minimal $HOME. Therefore, I used [the Arch Wiki](https://wiki.archlinux.org/title/DeveloperWiki:Building_in_a_clean_chroot) to implement Gemini's changes, tested those changes, and here we are.